### PR TITLE
Preserve folder structure for header files in headers/

### DIFF
--- a/Libyuv.podspec
+++ b/Libyuv.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |spec|
 
   spec.source_files = 'headers/*.h', 'headers/libyuv/*.h'
   spec.public_header_files = 'headers/*.h', 'headers/libyuv/*.h'
+  spec.header_mappings_dir = 'headers'
   spec.vendored_libraries  = 'lib/*.a'
   spec.requires_arc        = false
 


### PR DESCRIPTION
Without `spec.header_mappings_dir='headers'`, all header files are flatten to root include directory(`Pods/Headers/Public/Libyuv`), thus `libyuv.h` will not compile success. Here are some errors from [latest flutter-webrtc-demo](https://github.com/cloudwebrtc/flutter-webrtc-demo/tree/35f1a3d153cd60c110950ae97e784683601f127a/).

>    In file included from .pub-cache/hosted/pub.dartlang.org/flutter_webrtc-0.2.7/ios/Classes/FlutterRTCFrameCapturer.m:5:
>    In file included from flutter-webrtc-demo/ios/Pods/Libyuv/headers/libyuv.h:15:
>    flutter-webrtc-demo/ios/Pods/Libyuv/headers/libyuv/compare.h:14:10: fatal error: 'libyuv/basic_types.h' file not found
>    #include "libyuv/basic_types.h"
>             ^~~~~~~~~~~~~~~~~~~~~~
>    1 error generated.

From the error messages, seems that `libyuv` succeed to find `libyuv/basic_types.h` but `/libyuv/compare.h` can't . I think the `libyuv.h` included is `Pods/Libyuv/headers/libyuv.h` but not `Pods/Headers/Public/Libyuv/libyuv.h`.
